### PR TITLE
Added customFormatErrorFn to graphQLHTTP() and elucidate() to 'extensions' variable

### DIFF
--- a/demo/server/database/starwars_db_hardCoded.js.js
+++ b/demo/server/database/starwars_db_hardCoded.js.js
@@ -32,7 +32,7 @@ module.exports = {
             hair_color: "red",
             skin_color: "brown",
             birth_year: "07.31.2021",
-            gender: "female",
+            gender: "male",
             species_id: 31,
             homeworld_id: 32,
             height: 155,

--- a/demo/server/server.js
+++ b/demo/server/server.js
@@ -11,18 +11,68 @@ const app = express();
 
 app.use(express.json())
 
+function elucid(fn) {
+
+  function checkForError(res) {
+    // **CATEGORY 1: THE QUERY FAILS GRAPHQL INTERNAL VALIDATION (SYNTAX, SCHEMA LOGIC, ETC.)**
+
+    /* Query for specific post but not supplying required argument:
+    Check schema for query and its required arguments (non-nullable - 
+    if non nullable it will return 400 bad request and have specific error msg)
+    & validate incoming query*/
+
+    /* Query for specific post but supplying argument value not found:
+    check query against schema -if valid then add errors obj to indicate id not 
+    found, send 400 bad request*/
+
+    // **CATEGORY 2: AN UNCAUGHT DEV ERROR INSIDE THE RESOLVE/SUBSCRIBE FUNCTION**
+    
+    /* Resolver is malformed (e.g., 'source' argument is not provided):
+    Reset status code to 500 and alert about possible resolver issue*/
+
+    /* Resolver is malformed (given field argument is not supplied inside an object)*/
 
 
-app.use('/graphql', graphqlHTTP({
+
+
+    //if (res.statusCode === 200) console.log(res);//res.statusCode = 203;
+  }
+
+  return function(req, res, next) {
+    //console.log('res.statusCode before graphqlHTTP is ', res.statusCode);
+    fn(req, res).then(checkForError(res));
+  };
+}
+
+const extensions = ({
+  document,
+  variables,
+  operationName,
+  result,
+  context,
+}) => {
+  return {
+    testExt: Date.now() - context.startTime,
+  };
+};
+
+const handleErrorfromGQL_HTTP = (error) => ({
+  message: error.message,
+  locations: error.locations,
+  //stack: error.stack ? error.stack.split('\n') : [],
+  path: error.path,
+  statusCode: 500,
+});
+
+app.use('/graphql', elucid(graphqlHTTP({
   schema: schema,
   rootValue: resolvers,
   graphiql: true,
   pretty: true,
-  customFormatErrorFn: () => {
-    console.log("Hello World")
-  }
+  customFormatErrorFn: handleErrorfromGQL_HTTP,
+  extensions,
 }), 
-);
+));
 
 
 


### PR DESCRIPTION
- Overall framework for handling both Express-graphQL-detected and non-detected errors is now in place
- Ready for error handling checks to be added into elucidate()
- Comments are cleaned up and more comprehensive
- Apologies I forgot to co-author folks, is there a way to do it from here I couldn't find?